### PR TITLE
設定変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
herokuのビルド失敗していたのを修正を試みる
これを見た https://hackbaka.hatenablog.com/entry/2018/02/14/175948

```
I, [2018-12-15T06:06:09.835085 #1492]  INFO -- : Writing /tmp/build_7f755f3eda68955a34bd16de53de970e/public/assets/application-fbacdb1bf716e4009d7c179c0cd2cb3f42014fed637c57e6aee3cc9e583ad94c.js
       I, [2018-12-15T06:06:09.835646 #1492]  INFO -- : Writing /tmp/build_7f755f3eda68955a34bd16de53de970e/public/assets/application-fbacdb1bf716e4009d7c179c0cd2cb3f42014fed637c57e6aee3cc9e583ad94c.js.gz
       I, [2018-12-15T06:06:09.841918 #1492]  INFO -- : Writing /tmp/build_7f755f3eda68955a34bd16de53de970e/public/assets/application-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.css
       I, [2018-12-15T06:06:09.842645 #1492]  INFO -- : Writing /tmp/build_7f755f3eda68955a34bd16de53de970e/public/assets/application-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.css.gz
       rake aborted!
       Uglifier::Error: Unexpected token: string (controllers). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/uglifier-4.1.20/lib/uglifier.rb:234:in `parse_result'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/uglifier-4.1.20/lib/uglifier.rb:216:in `run_uglifyjs'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/uglifier-4.1.20/lib/uglifier.rb:168:in `compile'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/uglifier_compressor.rb:53:in `call'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/uglifier_compressor.rb:28:in `call'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:75:in `call_processor'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:57:in `block in call_processors'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:56:in `reverse_each'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:56:in `call_processors'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/loader.rb:134:in `load_from_unloaded'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/loader.rb:60:in `block in load'
       /tmp/build_7f755f3eda68955a34bd16de53de970e/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/loader.rb:317:in 
```